### PR TITLE
Add workflow to automatically update Haystack version in README.md

### DIFF
--- a/.github/workflows/update_haystack_version.yml
+++ b/.github/workflows/update_haystack_version.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Haystack version, e.g 1.13.0, 1.13.1"
+        description: "Haystack version, e.g v1.13.0, v1.13.1"
         required: true
         type: string
 
@@ -18,7 +18,7 @@ jobs:
 
       - name: Update README.md
         run: |
-          sed -i -r 's/Haystack is on v[0-9]+\.[0-9]+\.[0-9]+/Haystack is on v${{ inputs.version }}/g' profile/README.md
+          sed -i -r 's/Haystack is on v[0-9]+\.[0-9]+\.[0-9]+/Haystack is on ${{ inputs.version }}/g' profile/README.md
 
       - name: Commit and open PR
         env:

--- a/.github/workflows/update_haystack_version.yml
+++ b/.github/workflows/update_haystack_version.yml
@@ -1,0 +1,32 @@
+name: Update Haystack version in README.md
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Haystack version, e.g 1.13.0, 1.13.1"
+        required: true
+        type: string
+
+jobs:
+  update-readme:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Update README.md
+        run: |
+          sed -i -r 's/Haystack is on v[0-9]+\.[0-9]+\.[0-9]+/Haystack is on v${{ inputs.version }}/g' profile/README.md
+
+      - name: Commit and open PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b update-haystack-version
+          git commit --all -m "Update Haystack version"
+          git push -u origin update-haystack-version
+          gh pr create -B main --title 'Bump Haystack version to ${{ inputs.version }}' --fill -r devrel


### PR DESCRIPTION
Ideally the workflow will be run by a workflow or manually using the following command:

```
gh workflow run -R deepset-ai/.github update_haystack_version.yml -f "version=v1.1.1"
```

There's no validation done on the version input string so it requires a review.

I've tested on my fork, this is an example of [the PR](https://github.com/silvanocerza/.github/pull/1) that will be opened, and [related workflow run](https://github.com/silvanocerza/.github/actions/runs/4301770418/jobs/7499512956). In this repo it will add the `devrel` team as a reviewer.


For this to work correctly the **Workflow permissions** in repo settings must be set like so.
![image](https://user-images.githubusercontent.com/3314350/222117851-e4c79e55-7a8d-4356-8680-671bdcfd03a8.png)
