### PR TITLE
Fix version update PR creation

### DIFF
--- a/.github/workflows/update_haystack_version.yml
+++ b/.github/workflows/update_haystack_version.yml
@@ -29,4 +29,4 @@ jobs:
           git checkout -b update-haystack-version
           git commit --all -m "Update Haystack version"
           git push -u origin update-haystack-version
-          gh pr create -B main --title 'Bump Haystack version to ${{ inputs.version }}' --fill -r devrel
+          gh pr create -B main --title 'Bump Haystack version to ${{ inputs.version }}' --fill -r deepset-ai/devrel


### PR DESCRIPTION
This fixes `update_haystack_version.yml` workflow failing:
https://github.com/deepset-ai/.github/actions/runs/4353774431

I created this PR using the following command:

```
gh pr create -B main --title "Fix version update PR creation" --fill -r deepset-ai/devrel
```

Workflow that creates the version update PR runs an identical command, so it should be fixed.